### PR TITLE
Support Ruby 2.6+ again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ 3.0, head ]
+        ruby: [ 3.0, 2.7, 2.6, head ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/ext/pathname/pathname.c
+++ b/ext/pathname/pathname.c
@@ -341,6 +341,12 @@ path_realdirpath(int argc, VALUE *argv, VALUE self)
     return rb_class_new_instance(1, &str, rb_obj_class(self));
 }
 
+#ifndef RB_PASS_KEYWORDS
+/* Only define macros on Ruby <2.7 */
+#define rb_funcallv_kw(o, m, c, v, kw) rb_funcallv(o, m, c, v)
+#define rb_block_call_kw(o, m, c, v, f, p, kw) rb_block_call(o, m, c, v, f, p)
+#endif
+
 /*
  * call-seq:
  *   pathname.each_line {|line| ... }

--- a/pathname.gemspec
+++ b/pathname.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Representation of the name of a file or directory on the filesystem}
   spec.description   = %q{Representation of the name of a file or directory on the filesystem}
   spec.homepage      = "https://github.com/ruby/pathname"
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
 
   spec.metadata["homepage_uri"] = spec.homepage

--- a/pathname.gemspec
+++ b/pathname.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Representation of the name of a file or directory on the filesystem}
   spec.description   = %q{Representation of the name of a file or directory on the filesystem}
   spec.homepage      = "https://github.com/ruby/pathname"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
 
   spec.metadata["homepage_uri"] = spec.homepage

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -1068,6 +1068,7 @@ class TestPathname < Test::Unit::TestCase
   def test_split
     assert_equal([Pathname("dirname"), Pathname("basename")], Pathname("dirname/basename").split)
 
+    omit unless RUBY_VERSION >= '2.7.0'
     assert_separately([], <<-'end;')
       require 'pathname'
 

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -1466,6 +1466,7 @@ class TestPathname < Test::Unit::TestCase
   end
 
   def test_relative_path_from_casefold
+    omit unless RUBY_VERSION >= '2.7.0'
     assert_separately([], <<-'end;') #    do
       module File::Constants
         remove_const :FNM_SYSCASE

--- a/test/pathname/test_ractor.rb
+++ b/test/pathname/test_ractor.rb
@@ -4,7 +4,7 @@ require "pathname"
 
 class TestPathnameRactor < Test::Unit::TestCase
   def setup
-    skip unless defined? Ractor
+    omit unless defined? Ractor
   end
 
   def test_ractor_shareable


### PR DESCRIPTION
https://github.com/ruby/pathname/blob/a71f7d8ed28edae0db219dca7f76f6eaa74de41a/.github/workflows/test.yml#L10

This gem is testing only in Ruby 3.0+ since 0d1b754d3a32c2e26e5f9ed21a02b74489c0910a
Actually, old rubies can't finish tests.

`bin/setup; rake` failed as below.

On ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin20]
---

```
install -c tmp/x86_64-darwin20/pathname/2.7.2/pathname.bundle lib/pathname.bundle
cp tmp/x86_64-darwin20/pathname/2.7.2/pathname.bundle tmp/x86_64-darwin20/stage/lib/pathname.bundle
Loaded suite /Users/kachick/.gem/ruby/2.7.2/gems/rake-13.0.3/lib/rake/rake_test_loader
Started
...............................................................................
...............................................................................
...............................................................................
..............................................E
===============================================================================
Error: test_ractor_shareable(TestPathnameRactor): NameError: undefined local variable or method `skip' for #<TestPathnameRactor:0x00007ff6c7a2d878>
/Users/kachick/repos/pathname/test/pathname/test_ractor.rb:7:in `setup'
===============================================================================

Finished in 0.196045 seconds.
-------------------------------------------------------------------------------
284 tests, 368 assertions, 0 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
99.6479% passed
-------------------------------------------------------------------------------
1448.65 tests/s, 1877.12 assertions/s
rake aborted!
Command failed with status (1)
/Users/kachick/.gem/ruby/2.7.2/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```

On ruby 2.3.8p459 (2018-10-18 revision 65136) [x86_64-linux]
---

```
mkdir -p tmp/x86_64-linux/pathname/2.3.8
cd tmp/x86_64-linux/pathname/2.3.8
/usr/local/bin/ruby -I. ../../../../ext/pathname/extconf.rb
checking for rb_file_s_birthtime()... no
creating Makefile
cd -
cd tmp/x86_64-linux/pathname/2.3.8
/usr/bin/make
compiling ../../../../ext/pathname/pathname.c
../../../../ext/pathname/pathname.c: In function 'path_each_line':
../../../../ext/pathname/pathname.c:363:16: warning: implicit declaration of function 'rb_block_call_kw'; did you mean 'rb_block_call'? [-Wimplicit-function-declaration]
         return rb_block_call_kw(rb_cFile, id_foreach, 1+n, args, 0, 0, RB_PASS_CALLED_KEYWORDS);
                ^~~~~~~~~~~~~~~~
                rb_block_call
../../../../ext/pathname/pathname.c:363:72: error: 'RB_PASS_CALLED_KEYWORDS' undeclared (first use in this function)
         return rb_block_call_kw(rb_cFile, id_foreach, 1+n, args, 0, 0, RB_PASS_CALLED_KEYWORDS);
                                                                        ^~~~~~~~~~~~~~~~~~~~~~~
../../../../ext/pathname/pathname.c:363:72: note: each undeclared identifier is reported only once for each function it appears in
../../../../ext/pathname/pathname.c:366:16: warning: implicit declaration of function 'rb_funcallv_kw'; did you mean 'rb_funcallv'? [-Wimplicit-function-declaration]
         return rb_funcallv_kw(rb_cFile, id_foreach, 1+n, args, RB_PASS_CALLED_KEYWORDS);
                ^~~~~~~~~~~~~~
                rb_funcallv
../../../../ext/pathname/pathname.c: In function 'path_read':
../../../../ext/pathname/pathname.c:388:57: error: 'RB_PASS_CALLED_KEYWORDS' undeclared (first use in this function)
     return rb_funcallv_kw(rb_cFile, id_read, 1+n, args, RB_PASS_CALLED_KEYWORDS);
                                                         ^~~~~~~~~~~~~~~~~~~~~~~
../../../../ext/pathname/pathname.c: In function 'path_write':
../../../../ext/pathname/pathname.c:429:58: error: 'RB_PASS_CALLED_KEYWORDS' undeclared (first use in this function)
     return rb_funcallv_kw(rb_cFile, id_write, 1+n, args, RB_PASS_CALLED_KEYWORDS);
                                                          ^~~~~~~~~~~~~~~~~~~~~~~
../../../../ext/pathname/pathname.c: In function 'path_binwrite':
../../../../ext/pathname/pathname.c:450:61: error: 'RB_PASS_CALLED_KEYWORDS' undeclared (first use in this function)
     return rb_funcallv_kw(rb_cFile, id_binwrite, 1+n, args, RB_PASS_CALLED_KEYWORDS);
                                                             ^~~~~~~~~~~~~~~~~~~~~~~
../../../../ext/pathname/pathname.c: In function 'path_readlines':
../../../../ext/pathname/pathname.c:472:62: error: 'RB_PASS_CALLED_KEYWORDS' undeclared (first use in this function)
     return rb_funcallv_kw(rb_cFile, id_readlines, 1+n, args, RB_PASS_CALLED_KEYWORDS);
                                                              ^~~~~~~~~~~~~~~~~~~~~~~
../../../../ext/pathname/pathname.c: In function 'path_open':
../../../../ext/pathname/pathname.c:680:69: error: 'RB_PASS_CALLED_KEYWORDS' undeclared (first use in this function)
         return rb_block_call_kw(rb_cFile, id_open, 1+n, args, 0, 0, RB_PASS_CALLED_KEYWORDS);
                                                                     ^~~~~~~~~~~~~~~~~~~~~~~
../../../../ext/pathname/pathname.c: In function 'path_s_glob':
../../../../ext/pathname/pathname.c:1099:77: error: 'RB_PASS_CALLED_KEYWORDS' undeclared (first use in this function)
         return rb_block_call_kw(rb_cDir, id_glob, n, args, s_glob_i, klass, RB_PASS_CALLED_KEYWORDS);
                                                                             ^~~~~~~~~~~~~~~~~~~~~~~
../../../../ext/pathname/pathname.c: In function 'path_glob':
../../../../ext/pathname/pathname.c:1147:74: error: 'RB_PASS_KEYWORDS' undeclared (first use in this function)
         return rb_block_call_kw(rb_cDir, id_glob, n, args, glob_i, self, RB_PASS_KEYWORDS);
                                                                          ^~~~~~~~~~~~~~~~
../../../../ext/pathname/pathname.c:1161:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
../../../../ext/pathname/pathname.c: In function 'path_s_glob':
../../../../ext/pathname/pathname.c:1113:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
../../../../ext/pathname/pathname.c: In function 'path_open':
../../../../ext/pathname/pathname.c:685:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
../../../../ext/pathname/pathname.c: In function 'path_binwrite':
../../../../ext/pathname/pathname.c:451:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
../../../../ext/pathname/pathname.c: In function 'path_write':
../../../../ext/pathname/pathname.c:430:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
../../../../ext/pathname/pathname.c: In function 'path_readlines':
../../../../ext/pathname/pathname.c:473:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
../../../../ext/pathname/pathname.c: In function 'path_read':
../../../../ext/pathname/pathname.c:389:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
../../../../ext/pathname/pathname.c: In function 'path_each_line':
../../../../ext/pathname/pathname.c:368:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
Makefile:239: recipe for target 'pathname.o' failed
make: *** [pathname.o] Error 1
rake aborted!
Command failed with status (2): [/usr/bin/make...]
Tasks: TOP => default => compile => compile:x86_64-linux => compile:pathname:x86_64-linux => copy:pathname:x86_64-linux:2.3.8 => tmp/x86_64-linux/pathname/2.3.8/pathname.so
(See full trace by running task with --trace)
```
