### PR TITLE
Fix segmentation fault of `Pathname#split` when `File.split` returns non array value [Bug #17755]

### DIFF
--- a/ext/pathname/pathname.c
+++ b/ext/pathname/pathname.c
@@ -834,7 +834,7 @@ path_split(VALUE self)
     VALUE str = get_strpath(self);
     VALUE ary, dirname, basename;
     ary = rb_funcall(rb_cFile, id_split, 1, str);
-    ary = rb_check_array_type(ary);
+    Check_Type(ary, T_ARRAY);
     dirname = rb_ary_entry(ary, 0);
     basename = rb_ary_entry(ary, 1);
     dirname = rb_class_new_instance(1, &dirname, rb_obj_class(self));

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -1067,6 +1067,21 @@ class TestPathname < Test::Unit::TestCase
 
   def test_split
     assert_equal([Pathname("dirname"), Pathname("basename")], Pathname("dirname/basename").split)
+
+    assert_separately([], <<-'end;')
+      require 'pathname'
+
+      mod = Module.new do
+        def split(_arg)
+        end
+      end
+
+      File.singleton_class.prepend(mod)
+
+      assert_raise(TypeError) do
+        Pathname('/').split
+      end
+    end;
   end
 
   def test_blockdev?


### PR DESCRIPTION
ref: https://bugs.ruby-lang.org/issues/17755

```ruby
require 'pathname'

mod = Module.new do
  def split(_arg)
  end
end

File.singleton_class.prepend(mod)

Pathname('/').split
```

This code make segmentation fault.

```
-:10: [BUG] Segmentation fault at 0x0000000000000008
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
```

```text
Process:               ruby [58439]
Path:                  /Users/USER/*/ruby
Identifier:            ruby
Version:               0
Code Type:             X86-64 (Native)
Parent Process:        zsh [53848]
Responsible:           iTerm2 [775]
User ID:               501

Date/Time:             2021-03-27 15:46:16.534 +0900
OS Version:            macOS 11.2.3 (20D91)
Report Version:        12
Bridge OS Version:     5.2 (18P4347)
Anonymous UUID:        45AC3339-EF82-D14F-C1BE-DDCB9F9108C6

Sleep/Wake UUID:       E1F50CA2-5DC3-4ED1-AF17-7C63DE26EDF9

Time Awake Since Boot: 300000 seconds
Time Since Wake:       6000 seconds

System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGABRT)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000008
Exception Note:        EXC_CORPSE_NOTIFY

VM Regions Near 0x8:
--> 
    __TEXT                      10e0e0000-10e42c000    [ 3376K] r-x/r-x SM=COW  /Users/*

Application Specific Information:
abort() called

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fff203fd462 __pthread_kill + 10
1   libsystem_pthread.dylib       	0x00007fff2042b610 pthread_kill + 263
2   libsystem_c.dylib             	0x00007fff2037e720 abort + 120
3   ruby                          	0x000000010e18e3e9 die + 9 (error.c:750)
4   ruby                          	0x000000010e18e619 rb_bug_for_fatal_signal + 553 (error.c:790)
5   ruby                          	0x000000010e2cca7b sigsegv + 91 (signal.c:960)
6   libsystem_platform.dylib      	0x00007fff2046fd7d _sigtramp + 29
7   ???                           	000000000000000000 0 + 0
8   pathname.bundle               	0x000000010e63ffd7 path_split + 119 (pathname.c:838)
9   ruby                          	0x000000010e36b05f vm_call_cfunc_with_frame + 335 (vm_insnhelper.c:2898)
10  ruby                          	0x000000010e362f3c vm_sendish + 1324
11  ruby                          	0x000000010e348e70 vm_exec_core + 15920 (insns.def:789)
12  ruby                          	0x000000010e35da29 rb_vm_exec + 2873
13  ruby                          	0x000000010e199787 rb_ec_exec_node + 295 (eval.c:317)
14  ruby                          	0x000000010e199607 ruby_run_node + 87 (eval.c:375)
15  ruby                          	0x000000010e0e16fd main + 93 (main.c:50)
16  libdyld.dylib                 	0x00007fff20446621 start + 1

Thread 1:
0   libsystem_kernel.dylib        	0x00007fff203fd4fe poll + 10
1   ruby                          	0x000000010e318e2e timer_pthread_fn + 158 (thread_pthread.c:2189)
2   libsystem_pthread.dylib       	0x00007fff2042b950 _pthread_start + 224
3   libsystem_pthread.dylib       	0x00007fff2042747b thread_start + 15

Thread 0 crashed with X86 Thread State (64-bit):
  rax: 0x0000000000000000  rbx: 0x000000010e8e1e00  rcx: 0x00007f8f000d2fd8  rdx: 0x0000000000000000
  rdi: 0x0000000000000307  rsi: 0x0000000000000006  rbp: 0x00007f8f000d3000  rsp: 0x00007f8f000d2fd8
   r8: 0x00000000000130a8   r9: 0x00007fff88a65da8  r10: 0x000000010e8e1e00  r11: 0x0000000000000246
  r12: 0x0000000000000307  r13: 0x00007fff88a65f80  r14: 0x0000000000000006  r15: 0x0000000000000016
  rip: 0x00007fff203fd462  rfl: 0x0000000000000246  cr2: 0x0000000109e24000
  
Logical CPU:     0
Error Code:      0x02000148
Trap Number:     133

Thread 0 instruction stream:
  29 c9 4b 8d 0c fa 4e 8d-24 c9 4c 89 e7 48 89 c2  ).K...N.$.L..H..
  e8 fb 21 2a 00 4c 8b 43-18 4c 89 e6 4c 89 f8 48  ..!*.L.C.L..L..H
  f7 d8 48 8d 04 c6 48 89-43 20 e9 0e ff ff ff 48  ..H...H.C .....H
  89 df e8 25 ee 0a 00 48-8d 05 36 0c 36 00 48 8b  ...%...H..6.6.H.
  38 48 8d 35 6d 31 2a 00-31 c0 e8 bd 9a 0a 00 bf  8H.5m1*.1.......
  08 00 00 00 48 89 ce e8-40 dd 0c 00 55 48 89 e5  ....H...@...UH..
 [48]8b 0f f7 c1 00 20 00-00 75 14 48 8b 4f 10 48  H..... ..u.H.O.H	<==
  8b 7f 20 b8 08 00 00 00-48 85 c9 75 16 5d c3 c1  .. .....H..u.]..
  e9 0f 83 e1 03 48 83 c7-10 b8 08 00 00 00 48 85  .....H........H.
  c9 74 ea 48 85 f6 78 07-48 39 f1 7e e0 eb 05 48  .t.H..x.H9.~...H
  01 ce 78 d9 48 8b 04 f7-5d c3 66 90 55 48 89 e5  ..x.H...].f.UH..
  41 57 41 56 41 55 41 54-53 48 83 ec 18 49 89 ce  AWAVAUATSH...I..
  
Thread 0 last branch register state not available.


Binary Images:
       0x10e0e0000 -        0x10e42bfff +ruby (0) <C9D7ED14-0962-39AD-A0F2-C8B865D7B0E2> /Users/USER/*/ruby
       0x10e539000 -        0x10e598fff +libgmp.10.dylib (0) <3B2C7DB0-5829-3B4C-9522-1EF23C5E3226> /usr/local/opt/gmp/lib/libgmp.10.dylib
       0x10e60a000 -        0x10e60dfff +encdb.bundle (0) <0BA6F22A-E674-3777-8660-9DB07F46623C> /Users/USER/*/encdb.bundle
       0x10e61a000 -        0x10e61dfff +transdb.bundle (0) <09D9EC8D-E6F1-32F6-A6EF-5A4BA55D2124> /Users/USER/*/transdb.bundle
       0x10e62a000 -        0x10e62dfff +monitor.bundle (0) <317112D2-72B2-3312-B49F-D78FC23E2F8A> /Users/USER/*/monitor.bundle
       0x10e63a000 -        0x10e641fff +pathname.bundle (0) <089EE01F-AF79-3955-A8A6-5863C192B31F> /Users/USER/*/pathname.bundle
       0x10e80a000 -        0x10e8a5fff  dyld (832.7.3) <0D4EA85F-7E30-338B-9215-314A5A5539B6> /usr/lib/dyld
    0x7fff20160000 -     0x7fff20161fff  libsystem_blocks.dylib (78) <E644CAA0-65B7-36E4-8041-520F3301F3DB> /usr/lib/system/libsystem_blocks.dylib
    0x7fff20162000 -     0x7fff20197fff  libxpc.dylib (2038.80.3) <70F26262-01AA-3CEC-9FAD-2701D24096F0> /usr/lib/system/libxpc.dylib
    0x7fff20198000 -     0x7fff201affff  libsystem_trace.dylib (1277.80.2) <87FEF600-48D9-31C9-B8FC-D5249B2AE95D> /usr/lib/system/libsystem_trace.dylib
    0x7fff201b0000 -     0x7fff2024ffff  libcorecrypto.dylib (1000.80.5) <1EB11CFB-ABD7-36DD-97C7-C112A6601416> /usr/lib/system/libcorecrypto.dylib
    0x7fff20250000 -     0x7fff2027cfff  libsystem_malloc.dylib (317.40.8) <A498D1EF-E43D-310C-84E8-9C0AADA0C475> /usr/lib/system/libsystem_malloc.dylib
    0x7fff2027d000 -     0x7fff202c1fff  libdispatch.dylib (1271.40.12) <AD988EEA-1A2F-3404-9A6E-390FC2504223> /usr/lib/system/libdispatch.dylib
    0x7fff202c2000 -     0x7fff202fafff  libobjc.A.dylib (818.2) <EB6B543F-D42C-3FB2-A2EC-43407C5F80D3> /usr/lib/libobjc.A.dylib
    0x7fff202fb000 -     0x7fff202fdfff  libsystem_featureflags.dylib (28.60.1) <9CECB43A-094E-3CA9-B730-24DEA1A6DE05> /usr/lib/system/libsystem_featureflags.dylib
    0x7fff202fe000 -     0x7fff20386fff  libsystem_c.dylib (1439.40.11) <4AF71812-4099-3E96-B271-1F259491A2B2> /usr/lib/system/libsystem_c.dylib
    0x7fff20387000 -     0x7fff203dcfff  libc++.1.dylib (904.4) <B217D905-4F9C-3DE0-8844-88FAA3C2C851> /usr/lib/libc++.1.dylib
    0x7fff203dd000 -     0x7fff203f5fff  libc++abi.dylib (904.4) <3C9FE530-3CD2-3A64-8A36-70816AEBDF0D> /usr/lib/libc++abi.dylib
    0x7fff203f6000 -     0x7fff20424fff  libsystem_kernel.dylib (7195.81.3) <AB413518-ECDE-3F04-A61C-278D3CF43076> /usr/lib/system/libsystem_kernel.dylib
    0x7fff20425000 -     0x7fff20430fff  libsystem_pthread.dylib (454.80.2) <B989DF6C-ADFE-3AF9-9C91-07D2521F9E47> /usr/lib/system/libsystem_pthread.dylib
    0x7fff20431000 -     0x7fff2046bfff  libdyld.dylib (832.7.3) <4641E48F-75B5-3CC7-8263-47BF79F15394> /usr/lib/system/libdyld.dylib
    0x7fff2046c000 -     0x7fff20475fff  libsystem_platform.dylib (254.80.2) <1C3E1A0A-92A8-3CDE-B622-8940B43A5DF2> /usr/lib/system/libsystem_platform.dylib
    0x7fff20476000 -     0x7fff204a1fff  libsystem_info.dylib (542.40.3) <0C96CFE8-71F5-3335-8423-581BC3DE5846> /usr/lib/system/libsystem_info.dylib
    0x7fff204a2000 -     0x7fff2093dfff  com.apple.CoreFoundation (6.9 - 1774.101) <2A0E160E-9EE6-3B23-8832-6979A16EC250> /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
    0x7fff2093e000 -     0x7fff20b6dfff  com.apple.LaunchServices (1122.11 - 1122.11) <9ACD5692-3B92-3E6E-8B24-56ADCC911556> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
    0x7fff20b6e000 -     0x7fff20c41fff  com.apple.gpusw.MetalTools (1.0 - 1) <B1FDD261-7707-3E20-A6C2-99D9AF46356B> /System/Library/PrivateFrameworks/MetalTools.framework/Versions/A/MetalTools
    0x7fff20c42000 -     0x7fff20ea5fff  libBLAS.dylib (1336.40.1) <92702864-A5C6-3E22-86F6-DB329532674A> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
    0x7fff20ea6000 -     0x7fff20ef3fff  com.apple.Lexicon-framework (1.0 - 86.1) <2F429EBD-1BD2-3057-B760-8A81546DBD6F> /System/Library/PrivateFrameworks/Lexicon.framework/Versions/A/Lexicon
    0x7fff20ef4000 -     0x7fff20f62fff  libSparse.dylib (106) <B889DE4E-7356-3CC8-A13E-68D15E2024DF> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparse.dylib
    0x7fff20f63000 -     0x7fff20fe0fff  com.apple.SystemConfiguration (1.20 - 1.20) <3518EA0E-C32D-32CC-81B9-0F3C83B6430C> /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
    0x7fff20fe1000 -     0x7fff21016fff  libCRFSuite.dylib (50) <970D1F7B-5DBD-355F-80D8-C820AA1626D2> /usr/lib/libCRFSuite.dylib
    0x7fff21017000 -     0x7fff2124efff  libmecabra.dylib (929.1.1) <102A0AD8-D119-340B-B652-B75F0AAB1C7E> /usr/lib/libmecabra.dylib
    0x7fff2124f000 -     0x7fff215b2fff  com.apple.Foundation (6.9 - 1774.101) <8D9081B3-3F6A-31A0-9B20-1AE5CD8DD747> /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
    0x7fff215b3000 -     0x7fff2169ffff  com.apple.LanguageModeling (1.0 - 247.1) <1A05BCD7-232F-3950-936D-EC0F95BA3FB0> /System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
    0x7fff222dc000 -     0x7fff2262dfff  com.apple.security (7.0 - 59754.80.3) <B377D7C7-EDB6-3737-B492-E9872F4C6469> /System/Library/Frameworks/Security.framework/Versions/A/Security
    0x7fff2262e000 -     0x7fff2288ffff  libicucore.A.dylib (66109) <8F8D8A8B-4EE0-3C09-9F45-725A1FBDD38C> /usr/lib/libicucore.A.dylib
    0x7fff22890000 -     0x7fff22899fff  libsystem_darwin.dylib (1439.40.11) <E016D8F7-C87F-36F8-B8A0-6A61B8E4BACB> /usr/lib/system/libsystem_darwin.dylib
    0x7fff2289a000 -     0x7fff22b81fff  com.apple.CoreServices.CarbonCore (1307 - 1307) <B857EADF-D517-34E8-8053-34C0E6695250> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
    0x7fff22bc1000 -     0x7fff22bfbfff  com.apple.CSStore (1122.11 - 1122.11) <89992991-8538-380B-B2B8-4EA997CBFDBE> /System/Library/PrivateFrameworks/CoreServicesStore.framework/Versions/A/CoreServicesStore
    0x7fff22bfc000 -     0x7fff22caafff  com.apple.framework.IOKit (2.0.2 - 1845.81.1) <49AC0177-35A3-3C96-AD9D-3E59923C4761> /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
    0x7fff22cab000 -     0x7fff22cb6fff  libsystem_notify.dylib (279.40.4) <B2BF20C7-448A-3FBD-A2F5-AB7618D173F6> /usr/lib/system/libsystem_notify.dylib
    0x7fff24125000 -     0x7fff24768fff  libnetwork.dylib (2288.80.2) <A3F1E999-6D61-32D7-B3F7-67832CEA53CD> /usr/lib/libnetwork.dylib
    0x7fff24769000 -     0x7fff24c06fff  com.apple.CFNetwork (1220.1 - 1220.1) <04A917FB-DBFB-3432-BA4C-5B860990A420> /System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
    0x7fff24c07000 -     0x7fff24c15fff  libsystem_networkextension.dylib (1295.80.3) <5213D866-7D0E-3FD9-8E1A-03C0E39CEC44> /usr/lib/system/libsystem_networkextension.dylib
    0x7fff24c16000 -     0x7fff24c16fff  libenergytrace.dylib (22) <33A9FBF3-A2D3-3ECE-9370-B0ADDE3896DE> /usr/lib/libenergytrace.dylib
    0x7fff24c17000 -     0x7fff24c72fff  libMobileGestalt.dylib (978.80.1) <C4C7A5DC-C3AD-374D-902A-B6DED14FBB67> /usr/lib/libMobileGestalt.dylib
    0x7fff24c73000 -     0x7fff24c89fff  libsystem_asl.dylib (385) <5B48071E-85EB-33B0-AE9B-127AEB398AEC> /usr/lib/system/libsystem_asl.dylib
    0x7fff24c8a000 -     0x7fff24ca1fff  com.apple.TCC (1.0 - 1) <2F48471B-68F3-3017-8B18-BEDD4ED5853F> /System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
    0x7fff25fd1000 -     0x7fff26190fff  libsqlite3.dylib (321.1) <ACCC6A4C-3257-38A4-8AFB-BA73D906205B> /usr/lib/libsqlite3.dylib
    0x7fff262f5000 -     0x7fff2636afff  com.apple.AE (918.0.1 - 918.0.1) <9B6B42DB-8768-343B-B10E-A9A5710280CD> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
    0x7fff2636b000 -     0x7fff26371fff  libdns_services.dylib (1310.80.1) <97EB5DFD-BB41-3834-BF09-1F597D84F324> /usr/lib/libdns_services.dylib
    0x7fff26372000 -     0x7fff26379fff  libsystem_symptoms.dylib (1431.40.36) <BC85B46C-02EE-31FF-861D-F0DE01E8F6CF> /usr/lib/system/libsystem_symptoms.dylib
    0x7fff264ff000 -     0x7fff26523fff  com.apple.analyticsd (1.0 - 1) <4FFF906A-FE79-38F9-B777-AE878A0C99F1> /System/Library/PrivateFrameworks/CoreAnalytics.framework/Versions/A/CoreAnalytics
    0x7fff26524000 -     0x7fff26526fff  libDiagnosticMessagesClient.dylib (112) <20EDB261-69C7-3E4A-8C00-878814186A62> /usr/lib/libDiagnosticMessagesClient.dylib
    0x7fff26527000 -     0x7fff26573fff  com.apple.spotlight.metadata.utilities (1.0 - 2150.7.5) <FB7BF527-2D95-3E82-AAD8-D42B33DAC0F0> /System/Library/PrivateFrameworks/MetadataUtilities.framework/Versions/A/MetadataUtilities
    0x7fff26574000 -     0x7fff2660efff  com.apple.Metadata (10.7.0 - 2150.7.5) <49187239-597B-31A1-8895-8AA265C818C7> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
    0x7fff2660f000 -     0x7fff26615fff  com.apple.DiskArbitration (2.7 - 2.7) <ACFCD23E-05DF-3F96-BCFA-E294AAAFD2CE> /System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
    0x7fff26616000 -     0x7fff26cbcfff  com.apple.vImage (8.1 - 544.2) <3EBF95E1-30EB-3162-A9D4-B97BE581B69F> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
    0x7fff27204000 -     0x7fff27213fff  com.apple.OpenDirectory (11.2 - 230.40.1) <333A7F2E-0F3E-37F1-9E1B-69996F5084D2> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
    0x7fff27214000 -     0x7fff27233fff  com.apple.CFOpenDirectory (11.2 - 230.40.1) <25F138F8-9E55-3749-8271-0FDB275C3E2C> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
    0x7fff27234000 -     0x7fff2723cfff  com.apple.CoreServices.FSEvents (1290.40.2 - 1290.40.2) <6B70B98B-BCC5-3FBE-A6B5-CD0696AA055A> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
    0x7fff2723d000 -     0x7fff27261fff  com.apple.coreservices.SharedFileList (144 - 144) <C861FAD6-D3A5-302C-88AE-B2813F7201A7> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SharedFileList.framework/Versions/A/SharedFileList
    0x7fff27262000 -     0x7fff27264fff  libapp_launch_measurement.dylib (14.1) <2BBB708C-4D91-364E-ABD0-39BF198688A6> /usr/lib/libapp_launch_measurement.dylib
    0x7fff27265000 -     0x7fff272adfff  com.apple.CoreAutoLayout (1.0 - 21.10.1) <7A2E42E6-3AF2-3ECB-8A16-5C4AC41206EE> /System/Library/PrivateFrameworks/CoreAutoLayout.framework/Versions/A/CoreAutoLayout
    0x7fff272ae000 -     0x7fff27390fff  libxml2.2.dylib (34.9) <E0BF29C7-869B-3DD5-82AE-F36E6398091A> /usr/lib/libxml2.2.dylib
    0x7fff283c2000 -     0x7fff283d2fff  libsystem_containermanager.dylib (318.80.2) <6F08275F-B912-3D8E-9D74-4845158AE4F3> /usr/lib/system/libsystem_containermanager.dylib
    0x7fff283d3000 -     0x7fff283e4fff  com.apple.IOSurface (289.3 - 289.3) <029C5E16-2E04-3E98-BE25-CC8BAE5E3D19> /System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
    0x7fff283e5000 -     0x7fff283edfff  com.apple.IOAccelerator (439.52 - 439.52) <41EDF102-E1B5-3FBA-A74A-6C583CAA5D24> /System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
    0x7fff283ee000 -     0x7fff28513fff  com.apple.Metal (244.32.7 - 244.32.7) <829B9C4D-2DB6-38C9-9FE8-E6544FB3BDCC> /System/Library/Frameworks/Metal.framework/Versions/A/Metal
    0x7fff29073000 -     0x7fff290cefff  com.apple.MetalPerformanceShaders.MPSCore (1.0 - 1) <287C79B5-4E13-3DF6-BDC4-439EC621E010> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSCore.framework/Versions/A/MPSCore
    0x7fff290cf000 -     0x7fff290d2fff  libsystem_configuration.dylib (1109.60.2) <4917D824-4DE8-32CC-9ED2-1FBF371FEB9F> /usr/lib/system/libsystem_configuration.dylib
    0x7fff290d3000 -     0x7fff290d7fff  libsystem_sandbox.dylib (1441.60.4) <5F7F3DD1-4B38-310C-AA8F-19FF1B0F5276> /usr/lib/system/libsystem_sandbox.dylib
    0x7fff290d8000 -     0x7fff290d9fff  com.apple.AggregateDictionary (1.0 - 1) <E6C1A91D-4ADE-33CB-AA47-2F573811BFD9> /System/Library/PrivateFrameworks/AggregateDictionary.framework/Versions/A/AggregateDictionary
    0x7fff290da000 -     0x7fff290ddfff  com.apple.AppleSystemInfo (3.1.5 - 3.1.5) <4F8A1D06-3EFF-3174-BE9C-C4B70A3EA290> /System/Library/PrivateFrameworks/AppleSystemInfo.framework/Versions/A/AppleSystemInfo
    0x7fff290de000 -     0x7fff290dffff  liblangid.dylib (136) <E8044658-AE79-3930-A902-07A38BB22382> /usr/lib/liblangid.dylib
    0x7fff290e0000 -     0x7fff29180fff  com.apple.CoreNLP (1.0 - 245.1) <6C49B26B-CB39-3504-AD5E-9C3333FFE086> /System/Library/PrivateFrameworks/CoreNLP.framework/Versions/A/CoreNLP
    0x7fff29181000 -     0x7fff29187fff  com.apple.LinguisticData (1.0 - 399) <B059FF7F-731A-38F1-884A-588C6C8CA7F2> /System/Library/PrivateFrameworks/LinguisticData.framework/Versions/A/LinguisticData
    0x7fff29188000 -     0x7fff29845fff  libBNNS.dylib (288.80.1) <C5CD30D8-114B-3104-9020-E5C05E68CEE8> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBNNS.dylib
    0x7fff29846000 -     0x7fff29a19fff  libvDSP.dylib (760.40.6) <4CCEE561-A72B-33BC-B9F9-77A6CF2E7AF0> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
    0x7fff29a1a000 -     0x7fff29a2cfff  com.apple.CoreEmoji (1.0 - 128) <D43F3FFA-6692-3D56-ACBA-DDA40C566DDE> /System/Library/PrivateFrameworks/CoreEmoji.framework/Versions/A/CoreEmoji
    0x7fff29a2d000 -     0x7fff29a37fff  com.apple.IOMobileFramebuffer (343.0.0 - 343.0.0) <B15E9DA1-1C81-3ECF-94C7-FD137AD6C5E2> /System/Library/PrivateFrameworks/IOMobileFramebuffer.framework/Versions/A/IOMobileFramebuffer
    0x7fff29d3f000 -     0x7fff29dcbfff  com.apple.securityfoundation (6.0 - 55240.40.4) <72AC63B1-0B72-394F-97E8-BA9B114DD0A9> /System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
    0x7fff29dcc000 -     0x7fff29dd5fff  com.apple.coreservices.BackgroundTaskManagement (1.0 - 104) <EC15118E-62BD-3C24-A880-3B9B74318B0B> /System/Library/PrivateFrameworks/BackgroundTaskManagement.framework/Versions/A/BackgroundTaskManagement
    0x7fff29dd6000 -     0x7fff29ddafff  com.apple.xpc.ServiceManagement (1.0 - 1) <FD031028-B702-3909-B2AF-3916404DD4A8> /System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
    0x7fff29ddb000 -     0x7fff29dddfff  libquarantine.dylib (119.40.2) <40D35D75-524B-3DA6-8159-E7E0FA66F5BC> /usr/lib/system/libquarantine.dylib
    0x7fff29dde000 -     0x7fff29de9fff  libCheckFix.dylib (31) <74E17BB2-1A3C-3574-92DD-63ABE39E3FF9> /usr/lib/libCheckFix.dylib
    0x7fff29dea000 -     0x7fff29e01fff  libcoretls.dylib (169) <B33BEF87-3275-356D-9815-D0E94122D2EB> /usr/lib/libcoretls.dylib
    0x7fff29e02000 -     0x7fff29e12fff  libbsm.0.dylib (68.40.1) <D71EF121-D4B0-306E-9843-9FAFD558E3A4> /usr/lib/libbsm.0.dylib
    0x7fff29e13000 -     0x7fff29e5cfff  libmecab.dylib (929.1.1) <1F424683-4213-3594-9BF5-EFCCCDAA83A5> /usr/lib/libmecab.dylib
    0x7fff29e5d000 -     0x7fff29e62fff  libgermantok.dylib (24) <E40EFA11-E95C-36D1-A8BE-8CA5B1DD179D> /usr/lib/libgermantok.dylib
    0x7fff29e63000 -     0x7fff29e78fff  libLinearAlgebra.dylib (1336.40.1) <0D017F3F-6FD6-38DB-AA14-A64523A4D093> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
    0x7fff29e79000 -     0x7fff2a0a0fff  com.apple.MetalPerformanceShaders.MPSNeuralNetwork (1.0 - 1) <8FA469B3-48BE-315B-B3A0-C868CD541608> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSNeuralNetwork.framework/Versions/A/MPSNeuralNetwork
    0x7fff2a0a1000 -     0x7fff2a0f0fff  com.apple.MetalPerformanceShaders.MPSRayIntersector (1.0 - 1) <613BB6F1-3588-3E25-B523-059022FBE56E> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSRayIntersector.framework/Versions/A/MPSRayIntersector
    0x7fff2a0f1000 -     0x7fff2a238fff  com.apple.MLCompute (1.0 - 1) <01B968D9-A464-3667-8B8E-C99AEBA1FF79> /System/Library/Frameworks/MLCompute.framework/Versions/A/MLCompute
    0x7fff2a239000 -     0x7fff2a26ffff  com.apple.MetalPerformanceShaders.MPSMatrix (1.0 - 1) <B988D5F6-4E54-335D-A654-12C74FD668EA> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSMatrix.framework/Versions/A/MPSMatrix
    0x7fff2a270000 -     0x7fff2a2adfff  com.apple.MetalPerformanceShaders.MPSNDArray (1.0 - 1) <51ECDE6B-39F8-3BAB-ADC1-84C958F40A3F> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSNDArray.framework/Versions/A/MPSNDArray
    0x7fff2a2ae000 -     0x7fff2a33efff  com.apple.MetalPerformanceShaders.MPSImage (1.0 - 1) <D009508B-DCDF-3421-B1CB-40FDF4A68E93> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSImage.framework/Versions/A/MPSImage
    0x7fff2a33f000 -     0x7fff2a34efff  com.apple.AppleFSCompression (125 - 1.0) <879A04AA-F9A1-3640-A9EF-F5D0813C852A> /System/Library/PrivateFrameworks/AppleFSCompression.framework/Versions/A/AppleFSCompression
    0x7fff2a34f000 -     0x7fff2a35cfff  libbz2.1.0.dylib (44) <E163D5F9-E202-3A53-817B-8BC40B9293C0> /usr/lib/libbz2.1.0.dylib
    0x7fff2a35d000 -     0x7fff2a361fff  libsystem_coreservices.dylib (127) <529A0663-A936-309C-9318-1B04B7F70658> /usr/lib/system/libsystem_coreservices.dylib
    0x7fff2a362000 -     0x7fff2a38ffff  com.apple.CoreServices.OSServices (1122.11 - 1122.11) <8D30829B-426E-361E-B2A9-5850F1E5513D> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
    0x7fff2a565000 -     0x7fff2a577fff  libz.1.dylib (76) <6E2BD7A3-DC55-3183-BBF7-3AC367BC1834> /usr/lib/libz.1.dylib
    0x7fff2a578000 -     0x7fff2a5bffff  libsystem_m.dylib (3186.40.2) <DD26CC5C-AFF6-305F-A567-14909DD57163> /usr/lib/system/libsystem_m.dylib
    0x7fff2a5c0000 -     0x7fff2a5c0fff  libcharset.1.dylib (59) <D14F9D24-693A-37F0-8F92-D260248EB282> /usr/lib/libcharset.1.dylib
    0x7fff2a5c1000 -     0x7fff2a5c6fff  libmacho.dylib (973.4) <C2584BC4-497B-3170-ADDF-21B8E10B4DFD> /usr/lib/system/libmacho.dylib
    0x7fff2a5c7000 -     0x7fff2a5e2fff  libkxld.dylib (7195.81.3) <DE05C188-D9FE-30DC-8299-DF3DC9F837A5> /usr/lib/system/libkxld.dylib
    0x7fff2a5e3000 -     0x7fff2a5eefff  libcommonCrypto.dylib (60178.40.2) <822A29CE-BF54-35AD-BB15-8FAECB800C7D> /usr/lib/system/libcommonCrypto.dylib
    0x7fff2a5ef000 -     0x7fff2a5f9fff  libunwind.dylib (200.10) <1D0A4B4A-4370-3548-8DC1-42A7B4BD45D3> /usr/lib/system/libunwind.dylib
    0x7fff2a5fa000 -     0x7fff2a601fff  liboah.dylib (203.30) <44C477D9-013F-3A6D-A9FE-68A89214E6A5> /usr/lib/liboah.dylib
    0x7fff2a602000 -     0x7fff2a60cfff  libcopyfile.dylib (173.40.2) <39DBE613-135B-3AFE-A6AF-7898A37F70C2> /usr/lib/system/libcopyfile.dylib
    0x7fff2a60d000 -     0x7fff2a614fff  libcompiler_rt.dylib (102.2) <62EE1D14-5ED7-3CEC-81C0-9C93833641F1> /usr/lib/system/libcompiler_rt.dylib
    0x7fff2a615000 -     0x7fff2a617fff  libsystem_collections.dylib (1439.40.11) <C53D5E0C-0C4F-3B35-A24B-E0D7101A3F95> /usr/lib/system/libsystem_collections.dylib
    0x7fff2a618000 -     0x7fff2a61afff  libsystem_secinit.dylib (87.60.1) <E05E35BC-1BAB-365B-8BEE-D774189EFD3B> /usr/lib/system/libsystem_secinit.dylib
    0x7fff2a61b000 -     0x7fff2a61dfff  libremovefile.dylib (49.40.3) <5CC12A16-82CB-32F0-9040-72CFC88A48DF> /usr/lib/system/libremovefile.dylib
    0x7fff2a61e000 -     0x7fff2a61efff  libkeymgr.dylib (31) <803F6AED-99D5-3CCF-B0FA-361BCF14C8C0> /usr/lib/system/libkeymgr.dylib
    0x7fff2a61f000 -     0x7fff2a626fff  libsystem_dnssd.dylib (1310.80.1) <E0A0CAB3-6779-3C83-AC67-046CFE69F9C2> /usr/lib/system/libsystem_dnssd.dylib
    0x7fff2a627000 -     0x7fff2a62cfff  libcache.dylib (83) <1A98B064-8FED-39CF-BB2E-5BDA1EF5B65A> /usr/lib/system/libcache.dylib
    0x7fff2a62d000 -     0x7fff2a62efff  libSystem.B.dylib (1292.60.1) <83503CE0-32B1-36DB-A4F0-3CC6B7BCF50A> /usr/lib/libSystem.B.dylib
    0x7fff2a62f000 -     0x7fff2a632fff  libfakelink.dylib (3) <D939A124-9FD5-37A2-B03B-72E98CBC98FE> /usr/lib/libfakelink.dylib
    0x7fff2a633000 -     0x7fff2a633fff  com.apple.SoftLinking (1.0 - 1) <EF2AC5FF-B98D-3252-ABA8-2FC721CBA942> /System/Library/PrivateFrameworks/SoftLinking.framework/Versions/A/SoftLinking
    0x7fff2a634000 -     0x7fff2a66bfff  libpcap.A.dylib (98.40.1) <DE5787F8-D011-3E71-8323-936B35976D9E> /usr/lib/libpcap.A.dylib
    0x7fff2a66c000 -     0x7fff2a75cfff  libiconv.2.dylib (59) <AD10ECF4-E137-3152-9612-7EC548D919E8> /usr/lib/libiconv.2.dylib
    0x7fff2a75d000 -     0x7fff2a76efff  libcmph.dylib (8) <A5D1EBB3-70A1-3ECA-A3C7-E97FBAD36ECF> /usr/lib/libcmph.dylib
    0x7fff2a76f000 -     0x7fff2a7e0fff  libarchive.2.dylib (83.40.4) <9061C767-43FD-3483-9C48-73973AF82DC1> /usr/lib/libarchive.2.dylib
    0x7fff2a7e1000 -     0x7fff2a848fff  com.apple.SearchKit (1.4.1 - 1.4.1) <6243D4C0-3572-30A6-889A-B8690A5EAC24> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
    0x7fff2a849000 -     0x7fff2a84afff  libThaiTokenizer.dylib (3) <47CDE3EE-60AB-38CE-9494-5CC047CACA7F> /usr/lib/libThaiTokenizer.dylib
    0x7fff2a84b000 -     0x7fff2a872fff  com.apple.applesauce (1.0 - 16.26) <4A637FE0-A740-32F0-AE70-4593F6DF1573> /System/Library/PrivateFrameworks/AppleSauce.framework/Versions/A/AppleSauce
    0x7fff2a873000 -     0x7fff2a88afff  libapple_nghttp2.dylib (1.41) <A2F6DE8D-2B38-3669-A16E-E1BD54108F24> /usr/lib/libapple_nghttp2.dylib
    0x7fff2a88b000 -     0x7fff2a89dfff  libSparseBLAS.dylib (1336.40.1) <FC45F7FD-6B10-3F8D-A553-F57C757F6717> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparseBLAS.dylib
    0x7fff2a89e000 -     0x7fff2a89ffff  com.apple.MetalPerformanceShaders.MetalPerformanceShaders (1.0 - 1) <F37DBCE9-20CD-33D4-806B-93B326E08422> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/MetalPerformanceShaders
    0x7fff2a8a0000 -     0x7fff2a8a4fff  libpam.2.dylib (28.40.1) <FA3308D0-E7B4-3A2C-AE39-0E085F6CDEE0> /usr/lib/libpam.2.dylib
    0x7fff2a8a5000 -     0x7fff2a8bdfff  libcompression.dylib (96.40.6) <9C42DB2C-0A6D-38CE-BB8D-899A9B34B695> /usr/lib/libcompression.dylib
    0x7fff2a8be000 -     0x7fff2a8c3fff  libQuadrature.dylib (7) <55EE1866-623B-3C10-91FB-C8B06EB83995> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libQuadrature.dylib
    0x7fff2a8c4000 -     0x7fff2ac60fff  libLAPACK.dylib (1336.40.1) <2F92E8CD-396D-3665-88EB-41A4E1A9CB31> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
    0x7fff2ac61000 -     0x7fff2acaffff  com.apple.DictionaryServices (1.2 - 341) <5D0B1BB2-995B-32EB-AE75-F5F27127ACAF> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
    0x7fff2acb0000 -     0x7fff2acc8fff  liblzma.5.dylib (16) <168D84A7-8E54-361E-9161-B661D96C0C9A> /usr/lib/liblzma.5.dylib
    0x7fff2acc9000 -     0x7fff2accafff  libcoretls_cfhelpers.dylib (169) <80AF345B-1989-3C88-AEF4-8FF18A366A9C> /usr/lib/libcoretls_cfhelpers.dylib
    0x7fff2accb000 -     0x7fff2adc5fff  com.apple.APFS (1677.81.1 - 1677.81.1) <E48CCAAC-34B5-377E-8E5D-06CDBD411C2F> /System/Library/PrivateFrameworks/APFS.framework/Versions/A/APFS
    0x7fff2adc6000 -     0x7fff2add3fff  libxar.1.dylib (452) <FAA7B36E-21EC-3ADF-AA6A-E3742737CA3A> /usr/lib/libxar.1.dylib
    0x7fff2add4000 -     0x7fff2add7fff  libutil.dylib (58.40.2) <0A268749-08E7-3551-8969-442210651CCA> /usr/lib/libutil.dylib
    0x7fff2add8000 -     0x7fff2ae00fff  libxslt.1.dylib (17.3) <1C5219FB-B504-3658-B23B-2C45A3BA28F1> /usr/lib/libxslt.1.dylib
    0x7fff2ae01000 -     0x7fff2ae0bfff  libChineseTokenizer.dylib (37) <718400BF-9911-3CB6-8CCE-4C2D7C35D80A> /usr/lib/libChineseTokenizer.dylib
    0x7fff2ae0c000 -     0x7fff2aecafff  libvMisc.dylib (760.40.6) <9D11FCFC-6C30-32B6-864B-9CC3ED7D1143> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
    0x7fff2da66000 -     0x7fff2da66fff  liblaunch.dylib (2038.80.3) <C7C51322-8491-3B78-9CFA-2B4753662BCF> /usr/lib/system/liblaunch.dylib
    0x7fff2ff1a000 -     0x7fff2ff1afff  libsystem_product_info_filter.dylib (8.40.1) <20310EE6-2C3F-361A-9ECA-4223AFC03B65> /usr/lib/system/libsystem_product_info_filter.dylib
    0x7fff2fff5000 -     0x7fff2fff5fff  com.apple.Accelerate.vecLib (3.11 - vecLib 3.11) <8CD6F55A-8E4F-3653-A367-427D0ED3DD16> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
    0x7fff3001c000 -     0x7fff3001cfff  com.apple.CoreServices (1122.11 - 1122.11) <E59859C6-7221-3324-BB58-F910B2199959> /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
    0x7fff302ea000 -     0x7fff302eafff  com.apple.Accelerate (1.11 - Accelerate 1.11) <2423F0F6-A3A4-37AB-971E-FCFC7645D282> /System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
    0x7fff59101000 -     0x7fff5911cfff  libJapaneseConverter.dylib (90) <78F1A09D-07FD-34B0-8011-2ED89520133E> /System/Library/CoreServices/Encodings/libJapaneseConverter.dylib
    0x7fff6c97a000 -     0x7fff6c980fff  libCoreFSCache.dylib (177.22) <44489BD1-3963-35DF-86F1-DE95778AC0DB> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreFSCache.dylib

External Modification Summary:
  Calls made by other processes targeting this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by all processes on this machine:
    task_for_pid: 319742
    thread_create: 0
    thread_set_state: 0

VM Region Summary:
ReadOnly portion of Libraries: Total=575.5M resident=0K(0%) swapped_out_or_unallocated=575.5M(100%)
Writable regions: Total=119.4M written=0K(0%) resident=0K(0%) swapped_out=0K(0%) unallocated=119.4M(100%)
 
                                VIRTUAL   REGION 
REGION TYPE                        SIZE    COUNT (non-coalesced) 
===========                     =======  ======= 
Activity Tracing                   256K        1 
Kernel Alloc Once                    8K        1 
MALLOC                            90.1M       29 
MALLOC guard page                   16K        4 
STACK GUARD                          4K        1 
Stack                             8712K        2 
Stack Guard                       56.0M        1 
VM_ALLOCATE                       20.3M       66 
__DATA                            2602K      148 
__DATA_CONST                      6453K      101 
__DATA_DIRTY                       289K       59 
__LINKEDIT                       490.4M       14 
__OBJC_RO                         60.5M        1 
__OBJC_RW                         2449K        2 
__TEXT                            85.2M      150 
__UNICODE                          588K        1 
mapped file                       9176K        2 
shared memory                        8K        2 
===========                     =======  ======= 
TOTAL                            832.4M      585 
```