### PR TITLE
Support all rm_r options in Pathname#rmtree

### DIFF
--- a/lib/pathname.rb
+++ b/lib/pathname.rb
@@ -587,12 +587,12 @@ class Pathname    # * FileUtils *
 
   # Recursively deletes a directory, including all directories beneath it.
   #
-  # See FileUtils.rm_r
-  def rmtree(force: nil, noop: nil, verbose: nil, secure: nil)
+  # See FileUtils.rm_rf
+  def rmtree(noop: nil, verbose: nil, secure: nil)
     # The name "rmtree" is borrowed from File::Path of Perl.
     # File::Path provides "mkpath" and "rmtree".
     require 'fileutils'
-    FileUtils.rm_r(@path, force: force, noop: noop, verbose: verbose, secure: secure)
+    FileUtils.rm_rf(@path, noop: noop, verbose: verbose, secure: secure)
     nil
   end
 end

--- a/lib/pathname.rb
+++ b/lib/pathname.rb
@@ -588,11 +588,11 @@ class Pathname    # * FileUtils *
   # Recursively deletes a directory, including all directories beneath it.
   #
   # See FileUtils.rm_r
-  def rmtree
+  def rmtree(force: nil, noop: nil, verbose: nil, secure: nil)
     # The name "rmtree" is borrowed from File::Path of Perl.
     # File::Path provides "mkpath" and "rmtree".
     require 'fileutils'
-    FileUtils.rm_r(@path)
+    FileUtils.rm_r(@path, force: force, noop: noop, verbose: verbose, secure: secure)
     nil
   end
 end


### PR DESCRIPTION
This PR adds a fuller set of options passed through to the FileUtils method being supported on Pathname. Fixes #6 

## Question

`FileUtils#rmtree` was an alias for `FileUtils#rm_rf`.

This PR moves from `rm_r` to `rm_rf`, to reflect the API documentation notes.

**This is a change** of the implementation. 

Would you prefer to change the documentation OR the implementation?