### PR TITLE
Officially drop support for ruby 2.6 or older

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ '3.0', head ]
+        ruby: [ 2.7, '3.0', head ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         exclude:
         - { os: windows-latest , ruby: head }

--- a/pathname.gemspec
+++ b/pathname.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Representation of the name of a file or directory on the filesystem}
   spec.description   = %q{Representation of the name of a file or directory on the filesystem}
   spec.homepage      = "https://github.com/ruby/pathname"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
 
   spec.metadata["homepage_uri"] = spec.homepage

--- a/test/lib/core_assertions.rb
+++ b/test/lib/core_assertions.rb
@@ -695,7 +695,7 @@ eom
           msg = "exceptions on #{errs.length} threads:\n" +
             errs.map {|t, err|
             "#{t.inspect}:\n" +
-              RUBY_VERSION >= "2.5.0" ? err.full_message(highlight: false, order: :top) : err.message
+              err.full_message(highlight: false, order: :top)
           }.join("\n---\n")
           if message
             msg = "#{message}\n#{msg}"


### PR DESCRIPTION
The gem doesn't even install on old rubies, but since the gemspec claims it's supported, `gem install pathname` will try to install it and print an error.

This commit doesn't fix the above issue. The only way to fix it would be to restore support and release a new version that actually supports old rubies. However, such a change has been proposed and ignored for a long time. Also I noticed that [deprecating taint/untaint](https://github.com/ruby/pathname/commit/f9b1ab8eeede1f63fbd54aa3431bb419962b2f33#diff-9b8674a5c6d331aee2a6ff8e1ccf220166e8c66cf1862f875cde41daa7b022ed) was done without considering old rubies, so I think it's clear that maintainers don't want to support ruby 2.6.

So this issue proposes to leave that broken but at least bring the gemspec manifest and the CI matrix in sync to hopefully avoid this issue from happening again in the future.