### PR TITLE
Don't use bundle exec with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true # 'bundle install' and cache
+    - name: Install dependencies
+      run: bundle install
     - name: Run test
-      run: bundle exec rake compile test
+      run: rake compile test


### PR DESCRIPTION
pathname is activated by bundler, Because we can't test it under the bundler.