### PR TITLE
basename_sub

### DIFF
--- a/lib/pathname.rb
+++ b/lib/pathname.rb
@@ -544,6 +544,19 @@ class Pathname
       Pathname.new(File.join(*relpath_names))
     end
   end
+
+  # Return a pathname whose basename is substituted by String#sub.
+  #
+  #     path1 = Pathname.new('/usr/bin/perl')
+  #     path1.basename_sub('perl', 'ruby')
+  #         #=> #<Pathname:/usr/bin/ruby>
+  #     path1.basename_sub(/\Aperl\z/, 'ruby')
+  #         #=> #<Pathname:/usr/bin/ruby>
+  #
+  def basename_sub(pattern, replacement)
+    dir, base = split
+    dir + base.sub(pattern, replacement)
+  end
 end
 
 
@@ -597,4 +610,3 @@ class Pathname    # * FileUtils *
     nil
   end
 end
-

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -557,6 +557,15 @@ class TestPathname < Test::Unit::TestCase
 
   def pathsub(path, pat, repl) Pathname.new(path).sub(pat, repl).to_s end
   defassert(:pathsub, "a.o", "a.c", /\.c\z/, ".o")
+  defassert(:pathsub, "bar/bar", "bar/foo", "foo", "bar")
+
+  def pathbasesub(path, pat, repl) Pathname.new(path).basename_sub(pat, repl).to_s end
+  defassert(:pathbasesub, "a.o", "a.c", /\.c\z/, ".o")
+  defassert(:pathbasesub, "bar", "foo", "foo", "bar")
+  defassert(:pathbasesub, "bar", "foo", /\Afoo\z/, "bar")
+  defassert(:pathbasesub, "foo/bar", "foo/foo", "foo", "bar")
+  defassert(:pathbasesub, "foo/bar", "foo/foo", /\Afoo\z/, "bar")
+  defassert(:pathbasesub, "foo/fofo", "foo/foo", /\A(fo)o\z/, '\1\1')
 
   def pathsubext(path, repl) Pathname.new(path).sub_ext(repl).to_s end
   defassert(:pathsubext, 'a.o', 'a.c', '.o')


### PR DESCRIPTION
Hi,

This is a very simple complement to `sub` and `ext_sub`.  I believe `basename_sub` is more natural than `sub`, and in fact `sub`'s example is actually pretty-much an example of `basename_sub`.

`base_sub` is shorter, but looking at the API I went for `basename_sub`.  I might have been wrong.