### PR TITLE
use delete_prefix instead of sub in find method

### DIFF
--- a/lib/pathname.rb
+++ b/lib/pathname.rb
@@ -572,7 +572,7 @@ class Pathname    # * Find *
     return to_enum(__method__, ignore_error: ignore_error) unless block_given?
     require 'find'
     if @path == '.'
-      Find.find(@path, ignore_error: ignore_error) {|f| yield self.class.new(f.sub(%r{\A\./}, '')) }
+      Find.find(@path, ignore_error: ignore_error) {|f| yield self.class.new(f.delete_prefix('./')) }
     else
       Find.find(@path, ignore_error: ignore_error) {|f| yield self.class.new(f) }
     end


### PR DESCRIPTION
delete_prefix with a string is easier to read than a regular expression also it should be faster. It is available since ruby 2.5 and the gem requires ruby 2.7.