### PR TITLE
require fileutils in both methods using it

### DIFF
--- a/lib/pathname.rb
+++ b/lib/pathname.rb
@@ -580,14 +580,13 @@ class Pathname    # * Find *
 end
 
 
-autoload(:FileUtils, 'fileutils')
-
 class Pathname    # * FileUtils *
   # Creates a full path, including any intermediate directories that don't yet
   # exist.
   #
   # See FileUtils.mkpath and FileUtils.mkdir_p
   def mkpath(mode: nil)
+    require 'fileutils'
     FileUtils.mkpath(@path, mode: mode)
     nil
   end


### PR DESCRIPTION
rmtree is already requiring fileutils, but mkpath apparently relies on autoload of FileUtils. Switch to require for both methods