### PR TITLE
Remove check for File.birthtime

### DIFF
--- a/ext/pathname/extconf.rb
+++ b/ext/pathname/extconf.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: false
 require 'mkmf'
-have_func("rb_file_s_birthtime")
 create_makefile('pathname')

--- a/ext/pathname/pathname.c
+++ b/ext/pathname/pathname.c
@@ -479,7 +479,6 @@ path_atime(VALUE self)
     return rb_funcall(rb_cFile, id_atime, 1, get_strpath(self));
 }
 
-#if defined(HAVE_RB_FILE_S_BIRTHTIME)
 /*
  * call-seq:
  *   pathname.birthtime	-> time
@@ -494,10 +493,6 @@ path_birthtime(VALUE self)
 {
     return rb_funcall(rb_cFile, id_birthtime, 1, get_strpath(self));
 }
-#else
-/* check at compilation time for `respond_to?` */
-# define path_birthtime rb_f_notimplement
-#endif
 
 /*
  * call-seq:


### PR DESCRIPTION
File.birthtime has existed since Ruby 2.2, and pathname requires Ruby >= 2.7.0, so the method will always be there.