### PR TITLE
Make Pathname comparable

### DIFF
--- a/ext/pathname/pathname.c
+++ b/ext/pathname/pathname.c
@@ -1504,6 +1504,7 @@ Init_pathname(void)
     InitVM(pathname);
 
     rb_cPathname = rb_define_class("Pathname", rb_cObject);
+    rb_include_module(rb_cPathname, rb_mComparable);
     rb_define_method(rb_cPathname, "initialize", path_initialize, 1);
     rb_define_method(rb_cPathname, "freeze", path_freeze, 0);
     rb_define_method(rb_cPathname, "==", path_eq, 1);

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -555,6 +555,10 @@ class TestPathname < Test::Unit::TestCase
     assert_equal(nil, "a" <=> Pathname.new("a"))
   end
 
+  def test_comparable
+    assert(Pathname.ancestors.include?(Comparable))
+  end
+
   def pathsub(path, pat, repl) Pathname.new(path).sub(pat, repl).to_s end
   defassert(:pathsub, "a.o", "a.c", /\.c\z/, ".o")
 


### PR DESCRIPTION
Fixes [20676](https://bugs.ruby-lang.org/issues/20676)

I tried comparing pathnames to see if one was a subdirectory of another, and noticed it implements `<=>` but doesn't include `Comparable`.  This allows pathnames respond to comparison operators and methods like their backing strings do.