### PR TITLE
add Pathname.home

### DIFF
--- a/lib/pathname_builtin.rb
+++ b/lib/pathname_builtin.rb
@@ -165,6 +165,7 @@
 # These methods are a facade for Dir:
 # - Pathname.glob(*args)
 # - Pathname.getwd / Pathname.pwd
+# - Pathname.home
 # - #rmdir
 # - #entries
 # - #each_entry(&block)
@@ -1125,6 +1126,10 @@ class Pathname    # * Dir *
   class << self
     alias pwd getwd
   end
+
+  # See <tt>Dir.home</tt>.  Returns the home directory of the current user, or
+  # the named user if given, as a Pathname.
+  def Pathname.home(user_name = nil) self.new(Dir.home(user_name)) end
 
   # Return the entries (files and subdirectories) in the directory, each as a
   # Pathname object.

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -1364,6 +1364,15 @@ class TestPathname < Test::Unit::TestCase
     assert_kind_of(Pathname, wd)
   end
 
+  def test_s_home
+    home = Pathname.home
+    assert_kind_of(Pathname, home)
+    assert_equal(Dir.home, home.to_path)
+    user_home = Pathname.home(ENV['USER'])
+    assert_kind_of(Pathname, user_home)
+    assert_equal(Dir.home(ENV['USER']), user_home.to_path)
+  end
+
   def test_glob
     with_tmpchdir('rubytest-pathname') {|dir|
       Dir.mkdir("d")


### PR DESCRIPTION
now in Ruby, replacing https://github.com/ruby/pathname/pull/43
discussed in https://github.com/ruby/pathname/issues/37