### PR TITLE
Skip loading gem implementation on Ruby 4.0+

### DIFF
--- a/lib/pathname.rb
+++ b/lib/pathname.rb
@@ -10,8 +10,6 @@
 # For documentation, see class Pathname.
 #
 
-return if RUBY_VERSION >= '4.1'
-
 unless RUBY_VERSION >= '4'
   require 'pathname.so' if RUBY_ENGINE == 'ruby'
 

--- a/lib/pathname.rb
+++ b/lib/pathname.rb
@@ -10,27 +10,13 @@
 # For documentation, see class Pathname.
 #
 
-if defined?(::Pathname) # Clear builtin Pathname
-  # :stopdoc:
-  class ::Object
-    remove_const :Pathname
-  end
+return if RUBY_VERSION >= '4.1'
 
-  # Remove module_function Pathname
-  class << ::Kernel
-    undef Pathname
-  end
-  module ::Kernel
-    undef Pathname
-  end
+unless RUBY_VERSION >= '4'
+  require 'pathname.so' if RUBY_ENGINE == 'ruby'
 
-  $".delete('pathname.so')
-  # :startdoc:
+  require_relative 'pathname_builtin'
 end
-
-require 'pathname.so' if RUBY_ENGINE == 'ruby'
-
-require_relative 'pathname_builtin'
 
 class Pathname    # * Find *
   #

--- a/test/pathname/test_ractor.rb
+++ b/test/pathname/test_ractor.rb
@@ -8,6 +8,7 @@ class TestPathnameRactor < Test::Unit::TestCase
   end
 
   def test_ractor_shareable
+    omit "Ractor with Pathname is not supported on mingw" if /mingw/ =~ RUBY_PLATFORM
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     class Ractor
       alias value take


### PR DESCRIPTION
Ruby 4.0 makes Pathname a built-in class, and Ruby 4.1 will make all methods including `find`, `rmtree`, and `mktmpdir` built-in as well.

On Ruby 4.0, only the three additional methods are redefined from the gem. On Ruby 4.1+, the gem returns immediately and defers entirely to the built-in implementation if accept https://github.com/ruby/ruby/pull/16358.